### PR TITLE
Move attention mask to device in web ui demo

### DIFF
--- a/demo/requirements_web_demo.txt
+++ b/demo/requirements_web_demo.txt
@@ -1,2 +1,2 @@
-gradio==4.31.3
+gradio==4.44.0
 modelscope-studio

--- a/demo/web_demo_audio.py
+++ b/demo/web_demo_audio.py
@@ -87,7 +87,8 @@ def predict(chatbot, task_history):
     print(f"{audios=}")
     inputs = processor(text=text, audios=audios, return_tensors="pt", padding=True)
     if not _get_args().cpu_only:
-        inputs["input_ids"] = inputs.input_ids.to("cuda")
+        inputs["input_ids"] = inputs.input_ids.to(model.device)
+        inputs["attention_mask"] = inputs.attention_mask.to(model.device)
 
     generate_ids = model.generate(**inputs, max_length=256)
     generate_ids = generate_ids[:, inputs.input_ids.size(1):]


### PR DESCRIPTION
1. Move attention_mask of inputs to device as well, otherwise it will complain device not matching, if loading model to devices. Probably some changes in the model class in transformers, not sure why it's previous working.
2. Upgrade gradio version to 4.44.0 because in the requirements_web_demo.txt does not work. This was mentioned in issue #67 